### PR TITLE
Allow to silence "error handling stats line" messages

### DIFF
--- a/fixtures/rsyslog-stats.log
+++ b/fixtures/rsyslog-stats.log
@@ -1,4 +1,5 @@
 2017-08-30T08:09:54.776051+00:00 some-node.example.org rsyslogd-pstats: { "name": "global", "origin": "dynstats", "values": { } }
+2017-08-30T08:09:54.776052+00:00 some-node.example.org rsyslogd-pstats: { "name": "global", "origin": "percentile", "values": { } }
 2017-08-30T08:09:54.776072+00:00 some-node.example.org rsyslogd-pstats: { "name": "imuxsock", "origin": "imuxsock", "submitted": 9, "ratelimit.discarded": 0, "ratelimit.numratelimiters": 0 }
 2017-08-30T08:09:54.776082+00:00 some-node.example.org rsyslogd-pstats: { "name": "action 0", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }
 2017-08-30T08:09:54.776088+00:00 some-node.example.org rsyslogd-pstats: { "name": "to_exporter_2", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	certPath      = flag.String("tls.server-crt", "", "Path to PEM encoded file containing TLS server cert.")
 	keyPath       = flag.String("tls.server-key", "", "Path to PEM encoded file containing TLS server key (unencyrpted).")
+	silent        = flag.Bool("silent", false, "Disable logging of errors in handling stats lines")
 )
 
 func main() {
@@ -37,7 +38,7 @@ func main() {
 	}()
 
 	go func() {
-		exporter.run()
+		exporter.run(*silent)
 	}()
 
 	prometheus.MustRegister(exporter)

--- a/point.go
+++ b/point.go
@@ -23,10 +23,14 @@ type point struct {
 }
 
 func (p *point) promDescription() *prometheus.Desc {
+	variableLabels := []string{}
+	if p.promLabelName() != "" {
+		variableLabels = []string{p.promLabelName()}
+	}
 	return prometheus.NewDesc(
 		prometheus.BuildFQName("", "rsyslog", p.Name),
 		p.Description,
-		[]string{p.promLabelName()},
+		variableLabels,
 		nil,
 	)
 }


### PR DESCRIPTION
"error handling stats line" messages can be really noisy and can be ignored ignored in many cases (where module stats are not required/wanted).

This change adds a "-silent" flag to suppress those messages as well as e metric to count them (so an increase in rate can still be detected).

The new line in fixture file is from the [percentile-stats](https://www.rsyslog.com/doc/v8-stable/configuration/percentile_stats.html) component which seems to be enabled by default since rsyslog 8.2208.0